### PR TITLE
fix: add `symbol-alt-narrow` to `PEN`

### DIFF
--- a/main/en/currencies.json
+++ b/main/en/currencies.json
@@ -1253,7 +1253,8 @@
             "displayName": "Peruvian Sol",
             "displayName-count-one": "Peruvian sol",
             "displayName-count-other": "Peruvian soles",
-            "symbol": "PEN"
+            "symbol": "PEN",
+            "symbol-alt-narrow": "S/."
           },
           "PES": {
             "displayName": "Peruvian Sol (1863–1965)",


### PR DESCRIPTION
`PEN` currency symbol is `S/.`