### PR TITLE
Corrected time separator for en-AU

### DIFF
--- a/main/en-AU/numbers.json
+++ b/main/en-AU/numbers.json
@@ -27,7 +27,7 @@
           "perMille": "‰",
           "infinity": "∞",
           "nan": "NaN",
-          "timeSeparator": "."
+          "timeSeparator": ":"
         },
         "decimalFormats-numberSystem-latn": {
           "standard": "#,##0.###",


### PR DESCRIPTION
Australians use ":" as a time separator. See https://guides.service.gov.au/content-guide/numbers-measurements/#hours-and-minutes